### PR TITLE
fix: resolve semantic-release Date.prototype.toString error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,34 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Get latest tag before release
+        id: before
+        run: |
+          git fetch --tags
+          LATEST_TAG=$(git tag --sort=-v:refname | head -n1 || echo "")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
       - name: Run semantic-release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release
+
+          # Check for new tag created by semantic-release
+          git fetch --tags
+          NEW_TAG=$(git tag --sort=-v:refname | head -n1 || echo "")
+
+          if [ -n "$NEW_TAG" ] && [ "$NEW_TAG" != "${{ steps.before.outputs.latest_tag }}" ]; then
+            # Extract version without 'v' prefix
+            VERSION="${NEW_TAG#v}"
+            echo "new_release_published=true" >> $GITHUB_OUTPUT
+            echo "new_release_version=$VERSION" >> $GITHUB_OUTPUT
+            echo "New release published: $VERSION"
+          else
+            echo "new_release_published=false" >> $GITHUB_OUTPUT
+            echo "No new release published"
+          fi
 
       - name: Summary
         if: steps.semantic.outputs.new_release_published == 'true'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1464,16 +1464,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-      "integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.1.0.tgz",
+      "integrity": "sha512-MnbEysR8wWa8dAEvbj5xcBgJKQlX/m0lhS8DsyAAWDHdfs2faDJxTgzRYlRYpXSe7UiKrIIlB4TrBKU9q9DgkA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "release": "semantic-release",
     "release:dry": "semantic-release --dry-run"
   },
+  "overrides": {
+    "conventional-changelog-conventionalcommits": ">= 8.0.0"
+  },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",
     "@commitlint/config-conventional": "^19.0.0",


### PR DESCRIPTION
The cycjimmy/semantic-release-action@v4 bundles an incompatible version of conventional-changelog-conventionalcommits (v7) which causes a Date handling bug in conventional-changelog-writer during release notes generation.

Fix by:
1. Adding npm override for conventional-changelog-conventionalcommits >= 8.0.0
2. Running npx semantic-release directly instead of the action

This uses the project's local dependencies (with the override) instead of the action's bundled ones, avoiding the Date proxy issue.

Fixes: TypeError: Method Date.prototype.toString called on incompatible receiver