### PR TITLE
Add CI, release, license, and Docker Hub badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # 🐝 Odd Self-Hosted CI Runtime (OSCR)
 
+[![CI](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/ci.yml)
+[![Release](https://img.shields.io/github/v/release/oddessentials/odd-self-hosted-ci-runtime?display_name=tag&sort=semver)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/releases)
+[![License](https://img.shields.io/github/license/oddessentials/odd-self-hosted-ci-runtime)](LICENSE)
+[![Docker Hub Pulls (GitHub Runner)](https://img.shields.io/docker/pulls/oddessentials/oscr-github?label=docker%20pulls%20github)](https://hub.docker.com/r/oddessentials/oscr-github)
+[![Docker Hub Pulls (Azure DevOps Agent)](https://img.shields.io/docker/pulls/oddessentials/oscr-azure-devops?label=docker%20pulls%20azure)](https://hub.docker.com/r/oddessentials/oscr-azure-devops)
+
 **Docker-first, provider-pluggable self-hosted CI runtime.**
 
 Run your CI pipelines at zero cloud cost using your own hardware.


### PR DESCRIPTION
### Motivation
- Provide up-to-date project status and distribution metrics in the README by adding machine-updating badges for CI, releases, license and Docker pulls.
- A coverage badge was not added because the current CI does not publish coverage reports to a coverage service, so there is no reliable source to power a badge.

### Description
- Inserted status and distribution badges at the top of `README.md` for the GitHub Actions `ci.yml` workflow, GitHub releases (via `shields.io`), project license, and Docker Hub pulls for `oddessentials/oscr-github` and `oddessentials/oscr-azure-devops`.
- No other source files or logic were modified.

### Testing
- Ran `make verify` locally; the `format-check` step passed but `lint` failed because `shellcheck` is not installed in the environment (error: `shellcheck: command not found`).
- The repository already contains a GitHub Actions CI (`.github/workflows/ci.yml`) that runs ShellCheck and other quality gates and will reflect CI status via the new CI badge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971037084c88333975b02a35cfbc5f0)