### PR TITLE
docs: add badges for image size and commit conventions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![License](https://img.shields.io/github/license/oddessentials/odd-self-hosted-ci-runtime)](LICENSE)
 [![Docker Hub Pulls (GitHub Runner)](https://img.shields.io/docker/pulls/oddessentials/oscr-github?label=docker%20pulls%20github)](https://hub.docker.com/r/oddessentials/oscr-github)
 [![Docker Hub Pulls (Azure DevOps Agent)](https://img.shields.io/docker/pulls/oddessentials/oscr-azure-devops?label=docker%20pulls%20azure)](https://hub.docker.com/r/oddessentials/oscr-azure-devops)
+[![Docker Image Size (GitHub)](https://img.shields.io/docker/image-size/oddessentials/oscr-github/latest?label=image%20size%20github)](https://hub.docker.com/r/oddessentials/oscr-github)
+[![Docker Image Size (Azure)](https://img.shields.io/docker/image-size/oddessentials/oscr-azure-devops/latest?label=image%20size%20azure)](https://hub.docker.com/r/oddessentials/oscr-azure-devops)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![semantic-release: angular](https://img.shields.io/badge/semantic--release-angular-e10079?logo=semantic-release)](https://github.com/semantic-release/semantic-release)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
 **Docker-first, provider-pluggable self-hosted CI runtime.**
 


### PR DESCRIPTION
## Summary
Enhanced the README.md with additional badges to provide more visibility into project metrics and standards.

## Changes
- Added Docker image size badges for both GitHub Runner and Azure DevOps Agent images
- Added Conventional Commits badge to indicate adherence to commit message standards
- Added semantic-release badge to highlight automated versioning approach
- Added PRs Welcome badge to encourage community contributions

## Details
These badges serve to:
- Provide quick visibility into Docker image sizes for both CI runtime variants
- Signal to contributors that the project follows Conventional Commits specification
- Highlight the use of semantic-release for automated versioning
- Explicitly welcome pull requests from the community

All badges link to their respective resources (Docker Hub, conventionalcommits.org, semantic-release documentation, and makeapullrequest.com).