### PR TITLE
docs: add badges for smoke-test and publish workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # 🐝 Odd Self-Hosted CI Runtime (OSCR)
 
 [![CI](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/ci.yml/badge.svg)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/ci.yml)
+[![Self-Hosted Smoke Test](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/smoke-test.yml/badge.svg)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/smoke-test.yml)
+[![Publish Docker Images](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/publish.yml/badge.svg)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/actions/workflows/publish.yml)
 [![Release](https://img.shields.io/github/v/release/oddessentials/odd-self-hosted-ci-runtime?display_name=tag&sort=semver)](https://github.com/oddessentials/odd-self-hosted-ci-runtime/releases)
 [![License](https://img.shields.io/github/license/oddessentials/odd-self-hosted-ci-runtime)](LICENSE)
 [![Docker Hub Pulls (GitHub Runner)](https://img.shields.io/docker/pulls/oddessentials/oscr-github?label=docker%20pulls%20github)](https://hub.docker.com/r/oddessentials/oscr-github)


### PR DESCRIPTION
### Motivation
- Surface the status of existing GitHub Actions workflows by adding free workflow badges to the README so users can quickly see smoke-test and publish results.

### Description
- Insert two GitHub Actions badges into `README.md` that link to `.github/workflows/smoke-test.yml` and `.github/workflows/publish.yml`.

### Testing
- Ran `make verify` (which invokes `lint-shell` and `lint-yaml`) and `npm run lint:yaml`, both of which failed in this environment due to missing tools (`shellcheck` and `yamllint`), so no local linter success could be recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976552d449c8333ba62798d4b07a21d)